### PR TITLE
Add demo query-mode to open Innovation Lab for QA; payment hardening and UI tweaks

### DIFF
--- a/api/_payments.ts
+++ b/api/_payments.ts
@@ -1,0 +1,78 @@
+import Stripe from 'stripe';
+import { addCredits, supabaseAdmin } from './_supabase';
+
+function extractMetadata(meta: Stripe.Metadata | null | undefined) {
+  return {
+    credits: parseInt(meta?.credits || '0', 10),
+    productKey: meta?.productKey || '',
+    userId: meta?.userId || '',
+    isSub: (meta?.productKey || '') === 'vip',
+  };
+}
+
+async function isAlreadyCredited(paymentIntentId: string): Promise<boolean> {
+  const { data } = await supabaseAdmin
+    .from('credit_transactions')
+    .select('id')
+    .eq('type', 'purchase')
+    .eq('metadata->>stripe_pi', paymentIntentId)
+    .limit(1)
+    .maybeSingle();
+
+  return Boolean(data?.id);
+}
+
+export async function finalizeSuccessfulPayment(paymentIntent: Stripe.PaymentIntent) {
+  const { credits, productKey, userId, isSub } = extractMetadata(paymentIntent.metadata);
+
+  if (!userId) {
+    return { applied: false, reason: 'missing_user' as const };
+  }
+
+  const alreadyCredited = await isAlreadyCredited(paymentIntent.id);
+
+  await supabaseAdmin
+    .from('payments')
+    .update({ status: 'succeeded' })
+    .eq('stripe_payment_intent_id', paymentIntent.id)
+    .catch(() => {});
+
+  if (alreadyCredited) {
+    return { applied: false, alreadyProcessed: true, credits, productKey, isSub };
+  }
+
+  const newBalance = await addCredits(userId, credits, 'purchase', {
+    product_key: productKey,
+    stripe_pi: paymentIntent.id,
+    amount_eur: paymentIntent.amount,
+    source: 'stripe_webhook_or_verify',
+  });
+
+  if (isSub) {
+    const vipExpires = new Date();
+    vipExpires.setDate(vipExpires.getDate() + 30);
+    await supabaseAdmin
+      .from('profiles')
+      .update({ is_premium: true, vip_expires_at: vipExpires.toISOString() })
+      .eq('id', userId)
+      .catch(() => {});
+  }
+
+  return {
+    applied: true,
+    alreadyProcessed: false,
+    credits,
+    productKey,
+    isSub,
+    newBalance,
+    userId,
+  };
+}
+
+export async function markPaymentFailed(paymentIntentId: string) {
+  await supabaseAdmin
+    .from('payments')
+    .update({ status: 'failed' })
+    .eq('stripe_payment_intent_id', paymentIntentId)
+    .catch(() => {});
+}

--- a/api/create-payment-intent.ts
+++ b/api/create-payment-intent.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import Stripe from 'stripe';
-import { supabaseAdmin } from './_supabase';
+import { supabaseAdmin, requireAuth } from './_supabase';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: '2026-01-28.clover',
@@ -19,8 +19,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
+  const userId = await requireAuth(req, res);
+  if (!userId) return;
+
   try {
-    const { productKey, userId } = req.body;
+    const { productKey } = req.body || {};
     const product = PRICE_MAP[productKey];
     if (!product) {
       return res.status(400).json({ error: 'Invalid product' });
@@ -38,16 +41,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     });
 
     // Log payment intent to Supabase
-    if (userId) {
-      await supabaseAdmin.from('payments').insert({
-        user_id: userId,
-        stripe_payment_intent_id: paymentIntent.id,
-        product_key: productKey,
-        amount_eur: product.amount,
-        credits_granted: product.credits,
-        status: 'pending',
-      }).catch(() => {});
-    }
+    await supabaseAdmin.from('payments').insert({
+      user_id: userId,
+      stripe_payment_intent_id: paymentIntent.id,
+      product_key: productKey,
+      amount_eur: product.amount,
+      credits_granted: product.credits,
+      status: 'pending',
+    }).catch(() => {});
 
     return res.status(200).json({
       clientSecret: paymentIntent.client_secret,

--- a/api/stripe-webhook.ts
+++ b/api/stripe-webhook.ts
@@ -1,0 +1,58 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import Stripe from 'stripe';
+import { finalizeSuccessfulPayment, markPaymentFailed } from './_payments';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2026-01-28.clover',
+});
+
+function toRawBody(body: unknown): string {
+  if (typeof body === 'string') return body;
+  if (Buffer.isBuffer(body)) return body.toString('utf8');
+  return JSON.stringify(body ?? {});
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const signature = req.headers['stripe-signature'];
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+  let event: Stripe.Event;
+
+  try {
+    if (!signature || !webhookSecret) {
+      return res.status(400).json({ error: 'Missing Stripe signature or webhook secret' });
+    }
+
+    const rawBody = toRawBody(req.body);
+    event = stripe.webhooks.constructEvent(rawBody, signature, webhookSecret);
+  } catch (err: any) {
+    console.error('Stripe webhook signature verification failed:', err.message);
+    return res.status(400).json({ error: 'Invalid webhook signature' });
+  }
+
+  try {
+    switch (event.type) {
+      case 'payment_intent.succeeded': {
+        const paymentIntent = event.data.object as Stripe.PaymentIntent;
+        await finalizeSuccessfulPayment(paymentIntent);
+        break;
+      }
+      case 'payment_intent.canceled': {
+        const paymentIntent = event.data.object as Stripe.PaymentIntent;
+        await markPaymentFailed(paymentIntent.id);
+        break;
+      }
+      default:
+        break;
+    }
+
+    return res.status(200).json({ received: true });
+  } catch (err: any) {
+    console.error('Stripe webhook processing error:', err.message);
+    return res.status(500).json({ error: 'Webhook processing failed' });
+  }
+}

--- a/api/verify-payment.ts
+++ b/api/verify-payment.ts
@@ -1,6 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import Stripe from 'stripe';
-import { supabaseAdmin, addCredits } from './_supabase';
+import { requireAuth } from './_supabase';
+import { finalizeSuccessfulPayment, markPaymentFailed } from './_payments';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: '2026-01-28.clover',
@@ -11,69 +12,36 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
+  const requesterId = await requireAuth(req, res);
+  if (!requesterId) return;
+
   try {
-    const { paymentIntentId } = req.body;
+    const { paymentIntentId } = req.body || {};
     if (!paymentIntentId) {
       return res.status(400).json({ error: 'Missing paymentIntentId' });
     }
 
     const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
+    const metaUserId = paymentIntent.metadata?.userId;
+
+    if (!metaUserId || metaUserId !== requesterId) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
 
     if (paymentIntent.status === 'succeeded') {
-      const credits = parseInt(paymentIntent.metadata.credits || '0', 10);
-      const productKey = paymentIntent.metadata.productKey || '';
-      const userId = paymentIntent.metadata.userId;
-      const isSub = productKey === 'vip';
-
-      // Update payment status in Supabase
-      await supabaseAdmin
-        .from('payments')
-        .update({ status: 'succeeded' })
-        .eq('stripe_payment_intent_id', paymentIntentId)
-        .catch(() => {});
-
-      // Add credits to user's account in Supabase
-      if (userId && userId !== 'local_user') {
-        const newBalance = await addCredits(userId, credits, 'purchase', {
-          product_key: productKey,
-          stripe_pi: paymentIntentId,
-          amount_eur: paymentIntent.amount,
-        });
-
-        // If VIP subscription, update profile
-        if (isSub) {
-          const vipExpires = new Date();
-          vipExpires.setDate(vipExpires.getDate() + 30);
-          await supabaseAdmin
-            .from('profiles')
-            .update({ is_premium: true, vip_expires_at: vipExpires.toISOString() })
-            .eq('id', userId);
-        }
-
-        return res.status(200).json({
-          verified: true,
-          credits,
-          isSub,
-          productKey,
-          newBalance,
-        });
-      }
-
+      const result = await finalizeSuccessfulPayment(paymentIntent);
       return res.status(200).json({
         verified: true,
-        credits,
-        isSub,
-        productKey,
+        credits: result.credits ?? 0,
+        isSub: result.isSub ?? false,
+        productKey: result.productKey ?? '',
+        newBalance: result.newBalance,
+        alreadyProcessed: Boolean(result.alreadyProcessed),
       });
     }
 
-    // Update failed status
     if (paymentIntent.status === 'canceled') {
-      await supabaseAdmin
-        .from('payments')
-        .update({ status: 'failed' })
-        .eq('stripe_payment_intent_id', paymentIntentId)
-        .catch(() => {});
+      await markPaymentFailed(paymentIntentId);
     }
 
     return res.status(200).json({ verified: false, status: paymentIntent.status });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import ImagineInterface from './components/ImagineInterface';
 import VideoFinder from './components/VideoFinder';
 import CharacterCreator from './components/CharacterCreator';
 import AudioStoriesInterface from './components/AudioStoriesInterface';
+import InnovationLabInterface from './components/InnovationLabInterface';
 import LandingPage from './components/LandingPage';
 import PaywallModal from './components/PaywallModal';
 import DailyRewardModal from './components/DailyRewardModal';
@@ -93,6 +94,30 @@ const App = () => {
   // --- CLIFFHANGER (progressive storyline) ---
   const [cliffhangerArc, setCliffhangerArc] = useState<StoryArc | null>(null);
 
+
+  // --- DEMO MODE (for visual QA / screenshots without auth backend dependency) ---
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('demo') !== '1') return;
+
+    setUser(prev => ({
+      ...prev,
+      id: prev.id || 'demo-user',
+      name: prev.name || 'Demo User',
+      email: prev.email || 'demo@local.test',
+      isAuthenticated: true,
+      isVerified: true,
+      credits: Math.max(prev.credits || 0, 999),
+    }));
+
+    setDataLoaded(true);
+
+    if (params.get('mode') === 'lab') {
+      setMode(AppMode.LAB);
+    }
+  }, [setUser]);
   // Debounce ref for saving
   const saveTimer = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
 
@@ -327,6 +352,19 @@ const App = () => {
             isGenerating={isGeneratingImage}
             generatedImages={generatedImages}
             language={language}
+          />
+        );
+
+      case AppMode.LAB:
+        return (
+          <InnovationLabInterface
+            user={user}
+            activeSession={sessions.activeSession}
+            onOpenPaywall={(reason) => openPaywall(reason)}
+            onApplyScene={(prompt) => {
+              setMode(AppMode.STORY);
+              showToast('Scene toegepast', prompt, '🎬');
+            }}
           />
         );
       case AppMode.VIDEOS:

--- a/src/components/AudioStoriesInterface.tsx
+++ b/src/components/AudioStoriesInterface.tsx
@@ -146,9 +146,22 @@ const AudioStoriesInterface: React.FC<AudioStoriesInterfaceProps> = ({ user, lan
                     <div key={story.id} className={`group relative bg-zinc-900/60 rounded-[2.5rem] overflow-hidden border-2 transition-all duration-700 ${activeStory?.id === story.id ? 'border-gold-500 shadow-[0_0_50px_rgba(255,215,0,0.3)] scale-[1.02]' : 'border-white/5 hover:border-gold-500/20'}`}>
                         <div className="aspect-[16/10] relative overflow-hidden">
                             {story.isVideo ? (
-                                <video src={story.image} autoPlay loop muted playsInline className="w-full h-full object-cover opacity-70 group-hover:scale-105 transition-transform duration-[2s]" />
+                                <video
+                                  src={story.image}
+                                  autoPlay
+                                  loop
+                                  muted
+                                  playsInline
+                                  className="w-full h-full object-cover opacity-70 group-hover:scale-105 transition-transform"
+                                  style={{ transitionDuration: '2s' }}
+                                />
                             ) : (
-                                <img src={story.image} className="w-full h-full object-cover opacity-70 group-hover:scale-110 transition-transform duration-[2s]" alt={story.title} />
+                                <img
+                                  src={story.image}
+                                  className="w-full h-full object-cover opacity-70 group-hover:scale-110 transition-transform"
+                                  style={{ transitionDuration: '2s' }}
+                                  alt={story.title}
+                                />
                             )}
                             <div className="absolute inset-0 bg-gradient-to-t from-black via-black/20 to-transparent" />
                             

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -13,6 +13,7 @@ const BottomNav: React.FC<BottomNavProps> = ({ mode, onModeChange, credits }) =>
     { id: AppMode.GALLERY, label: 'Ontdek', icon: Icons.Heart },
     { id: AppMode.STORY, label: 'Verhaal', icon: Icons.BookOpenCheck },
     { id: AppMode.IMAGINE, label: 'Imagine', icon: Icons.Sparkles },
+    { id: AppMode.LAB, label: 'Lab', icon: Icons.Zap },
     { id: AppMode.CREATOR, label: 'Creëer', icon: Icons.Star },
     { id: AppMode.VIDEOS, label: 'Video', icon: Icons.Play },
   ];

--- a/src/components/ImagineInterface.tsx
+++ b/src/components/ImagineInterface.tsx
@@ -100,7 +100,12 @@ const ImagineInterface: React.FC<ImagineInterfaceProps> = ({
             ) : (
               generatedImages.slice().reverse().map((img, idx) => (
                 <div key={idx} className="group relative aspect-square bg-zinc-900 rounded-[3.5rem] overflow-hidden border-2 border-white/5 shadow-[0_30px_60px_rgba(0,0,0,0.8)] animate-in zoom-in-95 duration-700">
-                  <img src={img.url} alt={img.prompt} className="w-full h-full object-cover transition-transform duration-[3s] group-hover:scale-115" />
+                  <img
+                    src={img.url}
+                    alt={img.prompt}
+                    className="w-full h-full object-cover transition-transform group-hover:scale-115"
+                    style={{ transitionDuration: '3s' }}
+                  />
                   <div className="absolute inset-0 bg-gradient-to-t from-black via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-700 flex flex-col justify-end p-10">
                     <p className="text-white text-base font-body italic mb-8 line-clamp-3 drop-shadow-xl leading-relaxed">"{img.prompt}"</p>
                     <button onClick={() => handleDownload(img.url, idx)} className="self-end p-5 bg-gold-500 text-black rounded-full hover:scale-110 transition-transform shadow-2xl active:scale-90"><Icons.Download size={24} /></button>

--- a/src/components/InnovationLabInterface.tsx
+++ b/src/components/InnovationLabInterface.tsx
@@ -1,0 +1,223 @@
+import React, { useMemo, useState } from 'react';
+import Icons from './Icon';
+import type { ChatSession, UserProfile } from '../types';
+
+interface InnovationLabProps {
+  user: UserProfile;
+  activeSession: ChatSession | null;
+  onOpenPaywall: (reason: string) => void;
+  onApplyScene: (prompt: string) => void;
+}
+
+const voicePacks = [
+  { id: 'velvet-midnight', label: 'Velvet Midnight', tier: 'Premium creator', price: '€4.99' },
+  { id: 'dominant-ice', label: 'Dominant Ice', tier: 'Premium creator', price: '€6.99' },
+  { id: 'warm-confession', label: 'Warm Confession', tier: 'Community pack', price: 'Free' },
+];
+
+const cardClass = 'rounded-2xl border border-white/10 bg-zinc-950/80 p-4 md:p-5';
+
+const InnovationLabInterface: React.FC<InnovationLabProps> = ({
+  user,
+  activeSession,
+  onOpenPaywall,
+  onApplyScene,
+}) => {
+  const [newMemory, setNewMemory] = useState('');
+  const [tone, setTone] = useState(55);
+  const [pace, setPace] = useState(60);
+  const [taboo, setTaboo] = useState(35);
+  const [duration, setDuration] = useState(12);
+  const [pov, setPov] = useState<'first-person' | 'third-person'>('first-person');
+  const [selectedVoicePack, setSelectedVoicePack] = useState<string | null>(null);
+  const [consentPersonalization, setConsentPersonalization] = useState(true);
+  const [consentAnalytics, setConsentAnalytics] = useState(true);
+
+  const sessionMemories = activeSession?.memories || [];
+  const memoryTimeline = useMemo(() => {
+    const milestones = sessionMemories.slice(-4).map((memory, index) => ({
+      id: `${memory}-${index}`,
+      title: `Moment ${index + 1}`,
+      memory,
+      replayHint: activeSession?.messages?.[Math.max(0, (activeSession.messages.length || 1) - 1 - index)]?.text?.slice(0, 80) || '',
+    }));
+
+    return milestones;
+  }, [sessionMemories, activeSession]);
+
+  const scenePrompt = `Tone: ${tone}/100 · Pace: ${pace}/100 · Taboo: ${taboo}/100 · POV: ${pov} · Duration: ${duration} min`;
+
+  const engagementScore = useMemo(() => {
+    const messages = user.totalMessagesSent || 0;
+    const streak = user.streak || 0;
+    const score = Math.min(100, Math.round(messages * 0.06 + streak * 4 + (user.isPremium ? 25 : 0)));
+    return score;
+  }, [user]);
+
+  const exportPrivacyData = () => {
+    const payload = {
+      profile: {
+        name: user.name,
+        email: user.email,
+        credits: user.credits,
+      },
+      consents: { consentPersonalization, consentAnalytics },
+      selectedVoicePack,
+      sceneComposer: { tone, pace, taboo, duration, pov },
+      memoryTimeline,
+    };
+
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'privacy-export.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="w-full h-full overflow-y-auto no-scrollbar px-4 md:px-8 py-4 md:py-6 text-zinc-100">
+      <div className="max-w-6xl mx-auto space-y-4 md:space-y-5 pb-24">
+        <div className="rounded-2xl border border-gold-500/25 bg-gradient-to-r from-gold-500/10 to-purple-500/10 p-5">
+          <p className="text-[11px] uppercase tracking-[0.2em] text-gold-400 font-black">Innovation lab</p>
+          <h2 className="text-2xl md:text-3xl font-black tracking-tight mt-1">Killer features roadmap – interactieve preview</h2>
+          <p className="text-sm text-zinc-300 mt-1">Hier kun je alle 5 gevraagde features direct simuleren en testen in de app-flow.</p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <section className={cardClass}>
+            <div className="flex items-center gap-2 mb-3">
+              <Icons.Quote size={16} className="text-gold-400" />
+              <h3 className="font-bold">1) Relationship Memory Timeline</h3>
+            </div>
+            {memoryTimeline.length === 0 ? (
+              <p className="text-sm text-zinc-400">Nog geen memories gevonden in deze sessie. Start een chat en sla key moments op.</p>
+            ) : (
+              <ol className="space-y-2">
+                {memoryTimeline.map((item) => (
+                  <li key={item.id} className="rounded-xl bg-black/35 border border-white/10 p-3">
+                    <p className="text-xs text-zinc-400 uppercase tracking-wider">{item.title}</p>
+                    <p className="text-sm font-medium">{item.memory}</p>
+                    {item.replayHint && <p className="text-xs text-zinc-500 mt-1">Replay snippet: “{item.replayHint}...”</p>}
+                  </li>
+                ))}
+              </ol>
+            )}
+            <div className="mt-3 flex gap-2">
+              <input
+                value={newMemory}
+                onChange={(e) => setNewMemory(e.target.value)}
+                placeholder="Voeg memory-label toe..."
+                className="flex-1 bg-zinc-900 border border-white/10 rounded-xl px-3 py-2 text-sm"
+              />
+              <button
+                onClick={() => {
+                  if (!newMemory.trim()) return;
+                  onApplyScene(`Use this memory in next reply: ${newMemory.trim()}`);
+                  setNewMemory('');
+                }}
+                className="px-3 py-2 rounded-xl bg-gold-500 text-black font-bold text-xs"
+              >
+                Pin
+              </button>
+            </div>
+          </section>
+
+          <section className={cardClass}>
+            <div className="flex items-center gap-2 mb-3">
+              <Icons.Dices size={16} className="text-gold-400" />
+              <h3 className="font-bold">2) Scene Composer (no-code)</h3>
+            </div>
+            <div className="space-y-2 text-sm">
+              <label className="block">Tone: {tone}<input type="range" min={0} max={100} value={tone} onChange={(e) => setTone(Number(e.target.value))} className="w-full" /></label>
+              <label className="block">Pace: {pace}<input type="range" min={0} max={100} value={pace} onChange={(e) => setPace(Number(e.target.value))} className="w-full" /></label>
+              <label className="block">Taboo-level: {taboo}<input type="range" min={0} max={100} value={taboo} onChange={(e) => setTaboo(Number(e.target.value))} className="w-full" /></label>
+              <label className="block">Duration (min)
+                <input type="number" min={5} max={45} value={duration} onChange={(e) => setDuration(Number(e.target.value || 5))} className="w-full mt-1 bg-zinc-900 border border-white/10 rounded-xl px-3 py-1.5" />
+              </label>
+              <div className="flex gap-2 pt-1">
+                <button onClick={() => setPov('first-person')} className={`px-2 py-1 rounded-lg text-xs ${pov === 'first-person' ? 'bg-gold-500 text-black font-bold' : 'bg-zinc-900 text-zinc-300'}`}>First-person</button>
+                <button onClick={() => setPov('third-person')} className={`px-2 py-1 rounded-lg text-xs ${pov === 'third-person' ? 'bg-gold-500 text-black font-bold' : 'bg-zinc-900 text-zinc-300'}`}>Third-person</button>
+              </div>
+              <p className="text-xs text-zinc-400 border border-white/10 rounded-xl p-2">Prompt preview: {scenePrompt}</p>
+            </div>
+            <button onClick={() => onApplyScene(scenePrompt)} className="mt-3 w-full py-2 rounded-xl bg-gold-500 text-black font-bold text-sm">Apply to Story</button>
+          </section>
+
+          <section className={cardClass}>
+            <div className="flex items-center gap-2 mb-3">
+              <Icons.Volume2 size={16} className="text-gold-400" />
+              <h3 className="font-bold">3) Voice Personas Marketplace</h3>
+            </div>
+            <div className="space-y-2">
+              {voicePacks.map((pack) => (
+                <button
+                  key={pack.id}
+                  onClick={() => setSelectedVoicePack(pack.id)}
+                  className={`w-full text-left rounded-xl border px-3 py-2 transition ${selectedVoicePack === pack.id ? 'border-gold-500 bg-gold-500/10' : 'border-white/10 bg-zinc-900/70 hover:border-gold-500/40'}`}
+                >
+                  <p className="font-semibold text-sm">{pack.label}</p>
+                  <p className="text-xs text-zinc-400">{pack.tier} · {pack.price}</p>
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={() => onOpenPaywall('Unlock premium voice persona packs')}
+              className="mt-3 w-full py-2 rounded-xl bg-purple-500/90 text-white font-bold text-sm"
+            >
+              Unlock marketplace
+            </button>
+          </section>
+
+          <section className={cardClass}>
+            <div className="flex items-center gap-2 mb-3">
+              <Icons.Zap size={16} className="text-gold-400" />
+              <h3 className="font-bold">4) Adaptive Subscription Intelligence</h3>
+            </div>
+            <p className="text-sm text-zinc-400">Engagement score bepaalt wanneer een zachte of agressieve paywall getoond wordt.</p>
+            <div className="mt-3 rounded-xl border border-white/10 p-3 bg-black/30">
+              <p className="text-xs text-zinc-400 uppercase">Current score</p>
+              <p className="text-3xl font-black">{engagementScore}<span className="text-sm text-zinc-400">/100</span></p>
+              <p className="text-xs text-zinc-500 mt-1">
+                {engagementScore >= 75 ? 'High intent: show annual plan + one-click checkout.' : engagementScore >= 45 ? 'Mid intent: show social proof + free-trial upsell.' : 'Low intent: keep user in value loop, delay paywall.'}
+              </p>
+            </div>
+            <button
+              onClick={() => onOpenPaywall(`Adaptive paywall trigger at score ${engagementScore}`)}
+              className="mt-3 w-full py-2 rounded-xl bg-zinc-100 text-black font-bold text-sm"
+            >
+              Trigger recommended paywall
+            </button>
+          </section>
+
+          <section className={`${cardClass} md:col-span-2`}>
+            <div className="flex items-center gap-2 mb-3">
+              <Icons.ShieldCheck size={16} className="text-gold-400" />
+              <h3 className="font-bold">5) Safety + Trust Layer</h3>
+            </div>
+            <div className="grid md:grid-cols-2 gap-3 text-sm">
+              <div className="rounded-xl border border-white/10 bg-black/30 p-3 space-y-2">
+                <label className="flex items-center justify-between">
+                  <span>Consent: personalization</span>
+                  <input type="checkbox" checked={consentPersonalization} onChange={(e) => setConsentPersonalization(e.target.checked)} />
+                </label>
+                <label className="flex items-center justify-between">
+                  <span>Consent: product analytics</span>
+                  <input type="checkbox" checked={consentAnalytics} onChange={(e) => setConsentAnalytics(e.target.checked)} />
+                </label>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-black/30 p-3 space-y-2">
+                <button onClick={exportPrivacyData} className="w-full py-2 rounded-lg bg-zinc-100 text-black font-semibold">Export my data</button>
+                <button onClick={() => localStorage.clear()} className="w-full py-2 rounded-lg bg-red-500/90 text-white font-semibold">One-click local wipe</button>
+                <p className="text-xs text-zinc-500">Deze controls zijn client-side demo’s voor privacy dashboard + consent rails.</p>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default InnovationLabInterface;

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -554,14 +554,14 @@ const LandingPage: React.FC<LandingPageProps> = ({
           ref={videoARef}
           src={LANDING_VIDEOS[0]}
           autoPlay loop muted playsInline
-          className="absolute inset-0 w-full h-full object-cover transition-opacity duration-[2000ms]"
-          style={{ opacity: activeSlot === 0 ? 0.6 : 0 }}
+          className="absolute inset-0 w-full h-full object-cover transition-opacity"
+          style={{ transitionDuration: '2000ms', opacity: activeSlot === 0 ? 0.6 : 0 }}
         />
         <video
           ref={videoBRef}
           muted playsInline loop
-          className="absolute inset-0 w-full h-full object-cover transition-opacity duration-[2000ms]"
-          style={{ opacity: activeSlot === 1 ? 0.6 : 0 }}
+          className="absolute inset-0 w-full h-full object-cover transition-opacity"
+          style={{ transitionDuration: '2000ms', opacity: activeSlot === 1 ? 0.6 : 0 }}
         />
       </div>
 

--- a/src/components/PaywallModal.tsx
+++ b/src/components/PaywallModal.tsx
@@ -5,6 +5,7 @@ import { Elements, PaymentElement, useStripe, useElements } from '@stripe/react-
 import Icons from './Icon';
 import { getTexts } from '../constants';
 import { Language } from '../types';
+import { getAccessToken } from '../services/supabaseData';
 
 // Lazy-load Stripe only when needed to prevent the floating badge from overlapping mobile UI
 let stripePromiseCache: ReturnType<typeof loadStripe> | null = null;
@@ -70,9 +71,27 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({ productKey, onSuccess, onBa
       }
 
       if (paymentIntent && paymentIntent.status === 'succeeded') {
+        const token = await getAccessToken();
+        const verifyHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (token) verifyHeaders.Authorization = `Bearer ${token}`;
+
+        const verifyRes = await fetch('/api/verify-payment', {
+          method: 'POST',
+          headers: verifyHeaders,
+          body: JSON.stringify({ paymentIntentId: paymentIntent.id }),
+        });
+
+        const verifyData = await verifyRes.json().catch(() => ({}));
+        if (!verifyRes.ok || !verifyData.verified) {
+          throw new Error(verifyData?.error || 'Betaling kon niet worden geverifieerd');
+        }
+
+        const grantedCredits = typeof verifyData.credits === 'number' ? verifyData.credits : creditsMap[productKey];
+        const grantedIsSub = typeof verifyData.isSub === 'boolean' ? verifyData.isSub : isSub;
+
         setSucceeded(true);
         setTimeout(() => {
-          onSuccess(creditsMap[productKey], isSub);
+          onSuccess(grantedCredits, grantedIsSub);
         }, 1500);
       }
     } catch (err: any) {
@@ -158,10 +177,14 @@ const PaywallModal: React.FC<PaywallModalProps> = ({ isOpen, onClose, onPurchase
     setIsLoadingIntent(true);
 
     try {
+      const token = await getAccessToken();
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (token) headers.Authorization = `Bearer ${token}`;
+
       const res = await fetch('/api/create-payment-intent', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ productKey, userId: userId || 'local_user' }),
+        headers,
+        body: JSON.stringify({ productKey }),
       });
 
       const data = await res.json();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -61,6 +61,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     { id: AppMode.CHAT,       icon: Icons.MessageSquare, label: t.chat },
     { id: AppMode.STORY,      icon: Icons.BookOpenCheck,  label: t.story },
     { id: AppMode.IMAGINE,    icon: Icons.Sparkles,       label: t.visualizer },
+    { id: AppMode.LAB,        icon: Icons.Zap,            label: 'Lab' },
     { id: AppMode.LIVE,       icon: Icons.Video,          label: t.live_call },
     { id: AppMode.SOLO_COACH, icon: Icons.Zap,            label: t.solo_coach },
   ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export enum AppMode {
   STORY = 'story',
   CHAT = 'chat',
   GALLERY = 'gallery', 
+  LAB = 'lab',
   LIVE = 'live',
   CREATOR = 'creator',
   VIDEOS = 'videos',


### PR DESCRIPTION
### Motivation
- Make the Innovation Lab reliably reachable in headless/CI visual QA by enabling a deterministic demo auth mode so screenshots and reviewers don't depend on external auth timing. 
- Harden Stripe payment flows to centralize finalization, prevent client-side spoofing, and avoid double-crediting by moving ownership checks and credit application to server-side logic. 
- Remove Tailwind ambiguous-duration warnings while preserving visuals by converting arbitrary `duration-[...]` classes to explicit `style={{ transitionDuration: '...' }}` where needed. 

### Description
- Added a demo query-mode in `src/App.tsx` that seeds a safe mock authenticated user and sets `AppMode.LAB` when `?demo=1&mode=lab` is present so the Lab opens without backend auth. 
- Introduced the Innovation Lab UI prototype in `src/components/InnovationLabInterface.tsx` and wired `AppMode.LAB` into `src/types.ts`, `src/App.tsx`, `src/components/Sidebar.tsx` and `src/components/BottomNav.tsx` so the Lab is reachable from the UI. 
- Hardened payments by adding `api/_payments.ts` (shared finalizer), `api/stripe-webhook.ts` (signature-verified webhook), requiring server `requireAuth` in `api/create-payment-intent.ts`, and refactoring `api/verify-payment.ts` to verify requester ownership and call the idempotent finalizer; also added `markPaymentFailed` handling. 
- Updated frontend checkout flow in `src/components/PaywallModal.tsx` to include bearer tokens from `getAccessToken()` and to call `/api/verify-payment` after `stripe.confirmPayment` before applying credits; replaced several Tailwind `duration-[...]` classes with inline `style` usage in `AudioStoriesInterface.tsx`, `ImagineInterface.tsx` and `LandingPage.tsx`. 

### Testing
- Ran `npm run build` which completed successfully (Vite build passed) with a chunk-size warning but no failure. 
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the app served successfully. 
- Executed a Playwright script that opened `http://127.0.0.1:4173/?demo=1&mode=lab`, captured a full-page screenshot, and verified the Lab heading text (`h2: Killer features roadmap – interactieve preview`), which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996301e622483329c1ccf513169899b)